### PR TITLE
Use Min and 90th percentile thresholds if fitting fails

### DIFF
--- a/story.py
+++ b/story.py
@@ -117,7 +117,16 @@ def main():
             img = zarray[ci]
             if signed and img.min() < 0:
                 print("  WARNING: Ignoring negative pixel values", file=sys.stderr)
-            vmin, vmax = auto_threshold(img)
+            try:
+                vmin, vmax = auto_threshold(img)
+            except:
+                print("Auto threshold failed. Using original min and 90th percentile")
+                vmin = img.min()
+                vmax = np.quantile(img, 0.9)
+                if vmax == 0:
+                    vmax = 1
+                    
+
             vmin /= scale
             vmax /= scale
             channel_defs.append({

--- a/story.py
+++ b/story.py
@@ -120,7 +120,7 @@ def main():
             try:
                 vmin, vmax = auto_threshold(img)
             except:
-                print("Auto threshold failed. Using original min and 90th percentile")
+                #print("Auto threshold failed. Using original min and 90th percentile")
                 vmin = img.min()
                 vmax = np.quantile(img, 0.9)
                 if vmax == 0:

--- a/story.py
+++ b/story.py
@@ -120,9 +120,10 @@ def main():
             try:
                 vmin, vmax = auto_threshold(img)
             except:
-                #print("Auto threshold failed. Using original min and 90th percentile")
+                print("Auto threshold failed. Using original min and max")
                 vmin = img.min()
-                vmax = np.quantile(img, 0.9)
+                vmax = img.max()
+                #vmax = np.quantile(img, 0.9)
                 if vmax == 0:
                     vmax = 1
                     


### PR DESCRIPTION
- Files with high contrast ratio, or some pre-processing to remove noise artefacts, such as HTAN MIBI data received from Duke, may fail the fitting process. 
- If this fails, using the min value and 90th percentile as `vmin` and `vmax` is seen to give relatively robust success. 

Closes #8 

[![0_0_0](https://user-images.githubusercontent.com/14945787/155142241-dca38280-292d-436c-bffd-8297a22cee0b.jpg)](https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/high_mendel/minerva/index.html#s=0)