### PR TITLE
Update story.py to include "render" property

### DIFF
--- a/story.py
+++ b/story.py
@@ -129,6 +129,7 @@ def main():
             })
         story["groups"].append({
             "label": f"Group {gi}",
+            "render": channel_defs,
             "channels": channel_defs,
         })
 


### PR DESCRIPTION
This duplicates the "channels" property of each group as a "render" property. An equivalent solution would be to modify minerva author to perform this duplication itself when "render" isn't detected, as the distinction is only rarely important, for RGB images with a custom legend.